### PR TITLE
Updated the AI Review Generator & Setu product page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,7 @@ public/robots.txt
 
 # Claude Code internal files
 .claude/
+
+# Playwright MCP scratch artifacts (screenshots, snapshots, console logs)
+.playwright-mcp/
+reviews-full.jpeg

--- a/app/(main)/pricing/page.tsx
+++ b/app/(main)/pricing/page.tsx
@@ -4,7 +4,7 @@ import { Pricing } from '@/src/views/Pricing';
 export const metadata: Metadata = {
   title: 'Pricing — VyaptIX Products',
   description:
-    'Simple, transparent pricing for VyaptIX products. Start free with the AI Review Generator or discuss a custom AI automation engagement.',
+    'Simple, transparent pricing for VyaptIX products. AI Review Generator at ₹1,299/month launch pricing, Setu WhatsApp platform from ₹2,500/month, and custom AI automation engagements.',
   alternates: { canonical: 'https://vyaptix.com/pricing' },
 };
 

--- a/app/(main)/solutions/ai-review-generation/page.tsx
+++ b/app/(main)/solutions/ai-review-generation/page.tsx
@@ -2,9 +2,9 @@ import type { Metadata } from 'next';
 import { AIReviewGeneration } from '@/src/views/AIReviewGeneration';
 
 export const metadata: Metadata = {
-  title: 'AI Review Generator — Collect Google Reviews in Under 20 Seconds',
+  title: 'AI Review Generator — Get More Google Reviews on Autopilot',
   description:
-    'VyaptIX AI Review Generator lets customers scan a QR code and post a real Google review in under 20 seconds. Zero friction, authentic reviews.',
+    'VyaptIX AI Review Generator lets customers scan a QR code, answer a quick branded conversation, and post a real Google review in about 20 seconds. Plus AI-drafted replies to every review.',
   alternates: { canonical: 'https://vyaptix.com/solutions/ai-review-generation' },
 };
 

--- a/app/(main)/solutions/setu/page.tsx
+++ b/app/(main)/solutions/setu/page.tsx
@@ -2,9 +2,9 @@ import type { Metadata } from 'next';
 import { Setu } from '@/src/views/Setu';
 
 export const metadata: Metadata = {
-  title: 'Setu — WhatsApp Marketing & Automation Platform | VyaptIX',
+  title: 'Setu — WhatsApp Growth Platform | VyaptIX',
   description:
-    'Send campaigns to thousands, automate replies 24/7, manage your team inbox, and close more leads — all on WhatsApp. 98% open rate. Starts at ₹999/month. VyaptIX Setu.',
+    'Broadcast campaigns, 24/7 AI chatbot, shared team inbox, lead pipeline, and WhatsApp commerce — all on WhatsApp. 90%+ open rate. Plans from ₹2,500/month. VyaptIX Setu.',
   alternates: { canonical: 'https://vyaptix.com/solutions/setu' },
 };
 

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -15,18 +15,18 @@
 - Platform: https://reviews.vyaptix.ai
 - Page: https://vyaptix.com/solutions/ai-review-generation
 - Status: Live
-- What it does: Collects authentic Google reviews in under 20 seconds via QR code and AI-generated review text. Customers scan, rate, and the AI drafts a personalized review they post with one tap.
-- Key stats: 20 seconds per review, 3× average review growth, Google-policy compliant
+- What it does: Gets businesses more Google reviews on autopilot. Customers scan a branded QR code, answer a quick conversation, and the AI drafts a personalized review they post to Google with one tap — in about 20 seconds. Also includes a Google Review Inbox that drafts AI replies to reviews (owner approves each one), multi-store teams (up to 5 stores), analytics with CSV exports.
+- Key stats: about 20 seconds per review, 84% completion rate, 3× average review growth, Google-policy compliant, 50+ growing businesses
 - Use cases: Restaurants, retail, clinics, legal firms, real estate agencies
-- Pricing: Free tier available
+- Pricing: ₹1,299/month launch price (incl. 18% GST, down from ₹1,999), cancel anytime
 
-### Setu — WhatsApp Marketing & Automation
+### Setu — WhatsApp Growth Platform
 - Platform: https://setu.vyaptix.ai
 - Page: https://vyaptix.com/solutions/setu
 - Status: Live
-- What it does: WhatsApp broadcast campaigns, 24/7 AI chatbot, shared team inbox, contact CRM, lead pipeline (Kanban board), campaign analytics, role-based access. VyaptIX is a registered Meta Tech Provider.
-- Key stats: 98% message open rate, 3× higher reply rate vs email, live in 2 minutes
-- Pricing: From ₹999/month
+- What it does: WhatsApp broadcast campaigns, 24/7 AI chatbot with visual flow builder, shared team inbox, contact CRM, lead pipeline (Kanban board), WhatsApp commerce (catalogue, share-to-chat, order capture), media content library, campaign analytics, role-based access. VyaptIX is a registered Meta Tech Provider.
+- Key stats: 90%+ message open rate, 3× higher reply rate vs email, live in under 2 minutes, 18+ industries
+- Pricing: Growth ₹30,000/year (₹2,500/month), Pro ₹50,000/year (₹4,167/month), Enterprise ₹1,00,000/year (₹8,333/month) — all incl. 18% GST; Meta conversation fees billed separately at 0% markup
 
 ### BankLens — AI Credit Decisioning
 - Platform: https://banklens.vyaptix.ai

--- a/src/components/blocks/hero-section.tsx
+++ b/src/components/blocks/hero-section.tsx
@@ -25,8 +25,9 @@ interface HeroProps {
   badge?: {
     text: string;
     dot?: 'green' | 'amber' | 'blue';
+    icon?: React.ReactNode;
   };
-  title: string;
+  title: React.ReactNode;
   description: string;
   actions?: HeroAction[];
   image?: HeroImage;
@@ -49,6 +50,7 @@ export function HeroSection({ badge, title, description, actions, image, classNa
           {/* Badge */}
           {badge && (
             <div className="animate-appear inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-4 py-1.5 text-sm font-medium text-white/70">
+              {badge.icon}
               {badge.dot && (
                 <span
                   className={cn('h-2 w-2 rounded-full', {

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -29,13 +29,13 @@ const navItems: NavItem[] = [
         label: 'AI Review Generator',
         href: '/solutions/ai-review-generation',
         icon: <Star className="w-5 h-5" />,
-        description: 'Collect Google reviews in under 20 seconds',
+        description: 'Google reviews on autopilot — collect & reply with AI',
       },
       {
         label: 'Setu',
         href: '/solutions/setu',
         icon: <MessageCircle className="w-5 h-5" />,
-        description: 'WhatsApp marketing & automation',
+        description: 'WhatsApp campaigns, chatbot, inbox & commerce',
       },
       {
         label: 'BankLens',

--- a/src/components/ui/GoogleG.tsx
+++ b/src/components/ui/GoogleG.tsx
@@ -1,0 +1,27 @@
+/**
+ * Official multicolor Google "G" mark.
+ * Google, Google Business Profile, and the Google logo are trademarks of
+ * Google LLC — always pair prominent usage with the trademark disclaimer.
+ */
+export function GoogleG({ className = 'w-4 h-4' }: { className?: string }) {
+  return (
+    <svg viewBox="0 0 48 48" className={className} aria-label="Google" role="img">
+      <path
+        fill="#EA4335"
+        d="M24 9.5c3.54 0 6.71 1.22 9.21 3.6l6.85-6.85C35.9 2.38 30.47 0 24 0 14.62 0 6.51 5.38 2.56 13.22l7.98 6.19C12.43 13.72 17.74 9.5 24 9.5z"
+      />
+      <path
+        fill="#4285F4"
+        d="M46.98 24.55c0-1.57-.15-3.09-.38-4.55H24v9.02h12.94c-.58 2.96-2.26 5.48-4.78 7.18l7.73 6c4.51-4.18 7.09-10.36 7.09-17.65z"
+      />
+      <path
+        fill="#FBBC05"
+        d="M10.53 28.59c-.48-1.45-.76-2.99-.76-4.59s.27-3.14.76-4.59l-7.98-6.19C.92 16.46 0 20.12 0 24c0 3.88.92 7.54 2.56 10.78l7.97-6.19z"
+      />
+      <path
+        fill="#34A853"
+        d="M24 48c6.48 0 11.93-2.13 15.89-5.81l-7.73-6c-2.15 1.45-4.92 2.3-8.16 2.3-6.26 0-11.57-4.22-13.47-9.91l-7.98 6.19C6.51 42.62 14.62 48 24 48z"
+      />
+    </svg>
+  );
+}

--- a/src/views/AIReviewGeneration.tsx
+++ b/src/views/AIReviewGeneration.tsx
@@ -12,9 +12,9 @@ import {
   ExternalLink,
   Sparkles,
   TrendingUp,
-  Shield,
   Clock,
   Users,
+  MessageSquare,
   ShoppingBag,
   UtensilsCrossed,
   Stethoscope,
@@ -29,37 +29,38 @@ import {
 import { ScrollRevealGroup } from '../components/ui/ScrollRevealGroup';
 import { CountUp } from '../components/ui/CountUp';
 import { HeroSection } from '../components/blocks/hero-section';
+import { GoogleG } from '../components/ui/GoogleG';
 
 const features = [
   {
-    icon: <Shield className="w-6 h-6" />,
-    title: 'Google Compliant',
-    description: 'Fully compliant with Google review guidelines. Real customers, real reviews — no policy risk.',
-  },
-  {
-    icon: <Zap className="w-6 h-6" />,
-    title: 'Lightning Fast',
-    description: 'Customers complete the entire review process in under 20 seconds.',
-  },
-  {
     icon: <Sparkles className="w-6 h-6" />,
-    title: 'AI-Powered',
-    description: 'Advanced AI transforms simple feedback into detailed, authentic reviews.',
+    title: 'AI-Written Review Drafts',
+    description: 'Your customer answers a few quick questions and AI writes a natural, detailed review draft they can post as-is or edit.',
+  },
+  {
+    icon: <MessageSquare className="w-6 h-6" />,
+    title: 'Google Review Inbox',
+    description: "Reply to Google reviews with AI — on-brand drafts in your customer's language, and you approve every one before it goes out.",
   },
   {
     icon: <QrCode className="w-6 h-6" />,
-    title: 'Easy Sharing',
-    description: 'Generate QR codes and shareable links for seamless customer access.',
+    title: 'Branded QR Codes',
+    description: 'Custom branded QR codes and shareable links you can place wherever happy moments happen — counters, tables, receipts.',
+  },
+  {
+    icon: <Zap className="w-6 h-6" />,
+    title: 'Finished in 20 Seconds',
+    description: 'From QR scan to posted Google review in about 20 seconds — with an 84% completion rate.',
   },
   {
     icon: <BarChart3 className="w-6 h-6" />,
-    title: 'Real-Time Analytics',
-    description: 'Track reviews, ratings, and customer sentiment in your dashboard.',
+    title: 'Actionable Analytics',
+    description: 'Track scans, completions, ratings, and review growth in your dashboard, with CSV exports for reporting.',
   },
   {
     icon: <Users className="w-6 h-6" />,
-    title: 'Multi-Location',
-    description: 'Manage reviews across all your business locations from one dashboard.',
+    title: 'Multi-Store Teams',
+    description: 'Manage up to 5 stores from one account with owner and manager access levels for your team.',
   },
 ];
 
@@ -67,27 +68,22 @@ const howItWorks = [
   {
     step: '01',
     title: 'Create Your Store',
-    description: 'Set up your business profile in minutes. Add your Google Business link and customize your feedback form.',
+    description: 'Add your brand and Google Business Profile, and let AI prepare the questions your customers will answer.',
   },
   {
     step: '02',
-    title: 'Share With Customers',
-    description: 'Display your unique QR code at your location or send the link via email, SMS, or receipts.',
+    title: 'Share the QR',
+    description: 'Place your branded QR code wherever happy moments happen — counters, tables, receipts, or follow-up messages.',
   },
   {
     step: '03',
-    title: 'Customer Gives Feedback',
-    description: 'Customers rate their experience and add a few comments. Takes under 20 seconds.',
+    title: 'Customer Answers',
+    description: 'A quick, branded conversation captures the details of their experience. Takes about 20 seconds.',
   },
   {
     step: '04',
-    title: 'AI Generates Review',
-    description: 'Our AI instantly creates a personalized, detailed review based on their feedback.',
-  },
-  {
-    step: '05',
-    title: 'One-Click Post',
-    description: 'Customer copies the review and posts directly to Google. Done in seconds.',
+    title: 'AI Writes, Customer Posts',
+    description: 'The AI-drafted review is copied and Google opens instantly — your customer posts it in one tap.',
   },
 ];
 
@@ -122,20 +118,20 @@ const faqs = [
     answer: 'Yes, 100%. Our system encourages genuine customers to share authentic experiences. The AI helps articulate their feedback, but customers always have final control over what they post. We never create fake reviews or incentivize with discounts for reviews.',
   },
   {
-    question: 'What languages are supported?',
-    answer: 'Currently, we support English. Support for additional languages is on our roadmap — reach out to let us know your requirements.',
+    question: 'Can it reply to my existing Google reviews too?',
+    answer: "Yes. The Google Review Inbox drafts on-brand replies to your Google reviews — in your customer's language — and you approve every reply before it's posted. More reviews and faster replies lift how your business shows up on Google.",
   },
   {
-    question: 'Can I white-label this for my customers?',
-    answer: 'Yes! Our Pro and Enterprise plans include white-label options. You can customize the entire experience with your brand colors, logo, and domain. Perfect for agencies and multi-location businesses.',
+    question: 'Can I customize the experience with my branding?',
+    answer: 'Yes. Custom branding, custom questions, and branded QR codes are included in the plan. Each store gets its own branded experience, so the review flow feels like part of your brand — not another form.',
   },
   {
     question: "What's the average feedback-to-review time?",
-    answer: 'Most customers complete the entire flow in under 20 seconds. From scanning the QR code to posting on Google, the process is designed to be frictionless.',
+    answer: 'Most customers complete the entire flow in about 20 seconds, with an 84% completion rate. From scanning the QR code to posting on Google, the process is designed to be frictionless.',
   },
   {
-    question: 'Can I integrate with my CRM or POS system?',
-    answer: 'Yes, our Pro and Enterprise plans include API access for custom integrations. We also offer pre-built integrations with popular CRMs like Salesforce, HubSpot, and POS systems like Square and Toast.',
+    question: 'How much does it cost?',
+    answer: 'Launch pricing is ₹1,299/month (incl. 18% GST), down from ₹1,999 — cancel anytime. It includes self-serve setup, up to 5 stores, unlimited review drafts, custom branding and QR codes, analytics with CSV exports, team access, and email support with guided onboarding.',
   },
 ];
 
@@ -147,11 +143,11 @@ const softwareApplicationJsonLd = {
   operatingSystem: 'Web',
   url: 'https://reviews.vyaptix.ai',
   description:
-    'Collect authentic Google reviews in under 20 seconds using QR codes and AI-generated review text.',
+    'Get more Google reviews on autopilot. Customers answer a quick branded conversation, AI writes the review draft, and they post it straight to Google in about 20 seconds. Includes an AI-powered Google Review Inbox for replies.',
   offers: {
     '@type': 'Offer',
-    price: '0',
-    priceCurrency: 'USD',
+    price: '1299',
+    priceCurrency: 'INR',
     availability: 'https://schema.org/InStock',
   },
   provider: {
@@ -214,25 +210,49 @@ export function AIReviewGeneration() {
       </div>
 
       <HeroSection
-        badge={{ text: 'Live Platform', dot: 'green' }}
-        title="Collect Google Reviews in Under 20 Seconds"
-        description="Transform customer feedback into authentic Google reviews in seconds. Our AI understands sentiment and creates natural, personalized review text that customers are happy to post."
+        badge={{ text: 'Google Reviews, Made Effortless', icon: <GoogleG className="w-4 h-4" /> }}
+        title={
+          <>
+            Get More <span style={{ color: '#4285F4' }}>Google Reviews</span> — On Autopilot
+          </>
+        }
+        description="Turn great experiences into five-star stories. Every happy customer gets a fast, branded way to share their experience — they answer a quick conversation, AI writes the draft, and they post it straight to Google in about 20 seconds."
         actions={[
-          { text: 'Try Platform Free', href: 'https://reviews.vyaptix.ai', variant: 'primary', external: true },
+          { text: 'Create Your Account', href: 'https://reviews.vyaptix.ai', variant: 'primary', external: true },
           { text: 'Schedule Demo', href: '/demo', variant: 'secondary' },
         ]}
       />
+
+      {/* ── Google trust row ── */}
+      <section className="pb-12 bg-transparent">
+        <div className="container-main">
+          <div className="flex flex-wrap items-center justify-center gap-x-6 gap-y-3 text-sm text-slate-300">
+            <span className="flex items-center gap-1" aria-label="5 star rating">
+              {[...Array(5)].map((_, i) => (
+                <Star key={i} className="w-4 h-4 text-warning-400" fill="currentColor" />
+              ))}
+            </span>
+            <span className="flex items-center gap-2">
+              <GoogleG className="w-4 h-4" />
+              Reviews synced straight from Google
+            </span>
+            <span className="text-slate-400">50+ growing businesses collecting better reviews</span>
+          </div>
+        </div>
+      </section>
 
       {/* ── Features ── */}
       <section className="py-20 md:py-28 bg-[#0A1628] section-grid-light">
         <div className="container-main">
           <div className="text-center mb-14">
-            <p className="label-mono-cyan mb-3">Why Businesses Love It</p>
+            <p className="label-mono-cyan mb-3 flex items-center justify-center gap-2">
+              <GoogleG className="w-4 h-4" /> Everything for Your Google Reviews
+            </p>
             <h2 className="font-heading font-bold text-white mb-4" style={{ fontSize: 'clamp(1.8rem, 3.5vw, 2.8rem)' }}>
-              Everything You Need to Collect More Reviews
+              Collect Reviews, Reply with AI, Grow Your Rating
             </h2>
             <p className="text-slate-200 max-w-xl mx-auto">
-              A complete platform to grow your online presence and build trust.
+              A complete platform to collect Google reviews, reply to them with AI, and lift how your business shows up on Google.
             </p>
           </div>
           <ScrollRevealGroup className="grid md:grid-cols-2 lg:grid-cols-3 gap-6" staggerMs={80}>
@@ -252,6 +272,35 @@ export function AIReviewGeneration() {
         </div>
       </section>
 
+      {/* ── Google Business Profile banner ── */}
+      <section className="py-10 bg-[#0A1628] border-y border-white/10">
+        <div className="container-main">
+          <div className="flex flex-col md:flex-row items-center justify-between gap-6">
+            <div className="flex items-center gap-4">
+              <div className="w-12 h-12 rounded-full bg-white flex items-center justify-center flex-shrink-0">
+                <GoogleG className="w-6 h-6" />
+              </div>
+              <div>
+                <p className="font-semibold text-white">Works directly with your Google Business Profile</p>
+                <p className="text-sm text-slate-300">
+                  Reviews sync from Google and your replies post straight back — no copy-paste.
+                </p>
+              </div>
+            </div>
+            <div className="flex flex-wrap items-center gap-3">
+              <span className="inline-flex items-center gap-2 px-3 py-1.5 rounded-full border border-white/10 bg-white/5 text-xs font-medium text-slate-200">
+                <span className="w-1.5 h-1.5 rounded-full bg-success-400 animate-pulse" />
+                Live Google review sync
+              </span>
+              <span className="inline-flex items-center gap-2 px-3 py-1.5 rounded-full border border-white/10 bg-white/5 text-xs font-medium text-slate-200">
+                <CheckCircle className="w-3.5 h-3.5 text-success-400" />
+                You approve every reply
+              </span>
+            </div>
+          </div>
+        </div>
+      </section>
+
       {/* ── How It Works — animated stepper ── */}
       <section className="py-20 md:py-28 bg-[#050D1A]">
         <div className="container-main">
@@ -261,7 +310,7 @@ export function AIReviewGeneration() {
               How It Works
             </h2>
             <p className="text-slate-200 max-w-xl mx-auto">
-              A simple five-step process that turns customer interactions into valuable reviews.
+              A simple four-step process that turns happy customers into five-star Google reviews.
             </p>
           </div>
           <div ref={stepperRef} className="max-w-3xl mx-auto">
@@ -334,17 +383,18 @@ export function AIReviewGeneration() {
                 Start Growing Your Reviews Today
               </h2>
               <p className="text-lg text-slate-100 mb-6">
-                Our AI Review Generation platform is available as a standalone web application
-                at <strong className="text-white">reviews.vyaptix.ai</strong>. Create your free
-                account and start collecting reviews today.
+                Our AI Review Generator is available as a standalone web application
+                at <strong className="text-white">reviews.vyaptix.ai</strong>. Join 50+ growing
+                businesses collecting better reviews — launch pricing at ₹1,299/month
+                (incl. GST), down from ₹1,999. Cancel anytime.
               </p>
               <ul className="space-y-3 mb-8">
                 {[
-                  'Separate login for dedicated review management',
-                  'Full dashboard with analytics and insights',
-                  'Manage multiple locations from one account',
-                  'Export data and generate reports',
-                  'Priority support on paid plans',
+                  'Self-serve setup with guided onboarding',
+                  'Up to 5 stores and unlimited review drafts',
+                  'Custom branding, questions and QR codes',
+                  'Analytics, CSV exports and team access',
+                  'Google Review Inbox with AI-drafted replies',
                 ].map((item) => (
                   <li key={item} className="flex items-start gap-3">
                     <CheckCircle className="w-5 h-5 text-success-400 flex-shrink-0 mt-0.5" />
@@ -378,11 +428,11 @@ export function AIReviewGeneration() {
               <div className="p-6 space-y-4">
                 <div className="grid grid-cols-2 gap-4">
                   <div className="p-4 rounded-xl border border-white/10 bg-white/5">
-                    <BarChart3 className="w-5 h-5 text-primary-400 mb-2" />
+                    <TrendingUp className="w-5 h-5 text-primary-400 mb-2" />
                     <p className="text-2xl font-bold text-white">
-                      <CountUp value={847} duration={1500} />
+                      +<CountUp value={38} duration={1500} />
                     </p>
-                    <p className="text-xs text-slate-300 mt-0.5">Total Reviews</p>
+                    <p className="text-xs text-slate-300 mt-0.5">Reviews This Month</p>
                   </div>
                   <div className="p-4 rounded-xl border border-white/10 bg-white/5">
                     <Star className="w-5 h-5 text-warning-400 mb-2" />
@@ -391,11 +441,11 @@ export function AIReviewGeneration() {
                   </div>
                 </div>
                 <div className="p-4 rounded-xl border border-white/10 bg-white/5">
-                  <TrendingUp className="w-5 h-5 text-success-400 mb-2" />
+                  <BarChart3 className="w-5 h-5 text-success-400 mb-2" />
                   <p className="text-2xl font-bold text-white">
-                    +<CountUp value={127} suffix="%" duration={1800} />
+                    <CountUp value={84} suffix="%" duration={1800} />
                   </p>
-                  <p className="text-xs text-slate-300 mt-0.5">Growth This Month</p>
+                  <p className="text-xs text-slate-300 mt-0.5">Completion Rate</p>
                 </div>
                 <div className="p-4 rounded-xl bg-success-500/10 border border-success-500/20">
                   <div className="flex items-center gap-2">
@@ -450,8 +500,8 @@ export function AIReviewGeneration() {
             Ready to Grow Your Online Presence?
           </h2>
           <p className="text-lg text-slate-100 mb-8">
-            Start collecting reviews today with our AI-powered platform.
-            Free tier available, no credit card required.
+            Join 50+ growing businesses collecting better reviews.
+            Launch pricing at ₹1,299/month (incl. GST), down from ₹1,999 — cancel anytime.
           </p>
           <div className="flex flex-col sm:flex-row gap-4 justify-center">
             <a
@@ -460,7 +510,7 @@ export function AIReviewGeneration() {
               rel="noopener noreferrer"
               className="inline-flex items-center justify-center gap-2 px-8 py-4 font-semibold text-[#050D1A] bg-white rounded-lg hover:scale-[1.03] hover:shadow-[0_0_24px_rgba(6,206,255,0.3)] transition-all"
             >
-              Get Started Free <ExternalLink className="w-5 h-5" />
+              Create Your Account <ExternalLink className="w-5 h-5" />
             </a>
             <Link
               href="/demo"
@@ -469,6 +519,10 @@ export function AIReviewGeneration() {
               Schedule Demo
             </Link>
           </div>
+          <p className="text-xs text-slate-500 mt-10 max-w-2xl mx-auto">
+            Google, Google Business Profile, and the Google logo are trademarks of Google LLC.
+            VyaptIX is not affiliated with, endorsed by, or sponsored by Google.
+          </p>
         </div>
       </section>
     </>

--- a/src/views/Home.tsx
+++ b/src/views/Home.tsx
@@ -73,8 +73,8 @@ const products = [
   {
     num: '01',
     name: 'AI Review Generator',
-    tagline: 'More Google reviews, zero manual effort.',
-    hook: 'Customers scan a QR code, AI drafts the review, and it\'s published in under 20 seconds — no staff involvement.',
+    tagline: 'More Google reviews — on autopilot.',
+    hook: 'Customers scan a QR code, AI drafts the review, and it\'s posted to Google in about 20 seconds. Plus AI-drafted replies to every review you get.',
     status: 'LIVE',
     statusColor: '#4ADE80',
     statusBg: 'rgba(74,222,128,0.12)',
@@ -96,7 +96,7 @@ const products = [
     num: '02',
     name: 'Setu',
     tagline: 'Turn WhatsApp into your revenue channel.',
-    hook: 'Campaigns, 24/7 AI chatbot, shared team inbox, and a lead pipeline — all inside WhatsApp. Live in 2 minutes.',
+    hook: 'Campaigns, 24/7 AI chatbot, shared team inbox, lead pipeline, and WhatsApp commerce — all inside WhatsApp. Live in 2 minutes.',
     status: 'LIVE',
     statusColor: '#4ADE80',
     statusBg: 'rgba(74,222,128,0.12)',
@@ -110,7 +110,7 @@ const products = [
     href: '/solutions/setu',
     platform: 'setu.vyaptix.ai',
     stats: [
-      { value: '98%', label: 'open rate' },
+      { value: '90%+', label: 'open rate' },
       { value: '3×', label: 'reply rate vs email' },
     ],
   },

--- a/src/views/Pricing.tsx
+++ b/src/views/Pricing.tsx
@@ -5,67 +5,160 @@ import { CheckCircle, ArrowRight, Building2 } from 'lucide-react';
 import { Breadcrumb } from '../components/ui/Breadcrumb';
 import { HeroSection } from '../components/blocks/hero-section';
 
-const reviewPlans = [
+type Plan = {
+  name: string;
+  price: string;
+  period: string;
+  priceNote?: string;
+  description: string;
+  cta: string;
+  ctaHref: string;
+  ctaExternal: boolean;
+  highlighted: boolean;
+  badge?: string;
+  features: string[];
+};
+
+const reviewPlan: Plan = {
+  name: 'Launch Plan',
+  price: '₹1,299',
+  period: '/ month',
+  priceNote: 'Down from ₹1,999 · incl. 18% GST',
+  description: 'Everything you need to collect Google reviews and reply with AI. Cancel anytime.',
+  cta: 'Create Your Account',
+  ctaHref: 'https://reviews.vyaptix.ai',
+  ctaExternal: true,
+  highlighted: true,
+  badge: 'Launch Offer',
+  features: [
+    'Self-serve setup with guided onboarding',
+    'Up to 5 stores',
+    'Unlimited AI review drafts',
+    'Google Review Inbox with AI-drafted replies',
+    'Custom branding, questions & QR codes',
+    'Analytics, CSV exports & team access',
+    'Email support',
+  ],
+};
+
+const setuPlans: Plan[] = [
   {
-    name: 'Starter',
-    price: 'Free',
-    period: '',
-    description: 'Try the platform with your first location — no credit card required.',
-    cta: 'Start Free',
-    ctaHref: 'https://reviews.vyaptix.ai',
+    name: 'Growth',
+    price: '₹2,500',
+    period: '/ month',
+    priceNote: '₹30,000 billed annually',
+    description: 'Core features for emerging operations.',
+    cta: 'Get Started',
+    ctaHref: 'https://setu.vyaptix.ai',
     ctaExternal: true,
     highlighted: false,
     features: [
-      '1 business location',
-      'Up to 30 review requests / month',
-      'QR code + shareable link',
-      'AI-generated review text',
-      'Basic analytics dashboard',
-      'Google My Business integration',
+      'Broadcast campaigns',
+      '24/7 AI chatbot & flows',
+      'Shared team inbox',
+      'Contact CRM & segments',
+      'Website widget',
+      'Campaign analytics',
+      'Commerce basics',
+      'Email support',
     ],
   },
   {
     name: 'Pro',
-    price: '$49',
+    price: '₹4,167',
     period: '/ month',
-    description: 'For growing businesses that need volume and brand control.',
+    priceNote: '₹50,000 billed annually',
+    description: 'For scaling teams that need more volume and commerce.',
     cta: 'Get Started',
-    ctaHref: 'https://reviews.vyaptix.ai',
+    ctaHref: 'https://setu.vyaptix.ai',
     ctaExternal: true,
     highlighted: true,
     badge: 'Most Popular',
     features: [
-      'Up to 5 business locations',
-      'Unlimited review requests',
-      'Custom branded experience',
-      'White-label QR codes',
-      'Advanced analytics & reporting',
-      'Multi-language review text',
-      'Priority email support',
-      'API access',
+      'Everything in Growth',
+      'Expanded commerce catalogue',
+      'Higher usage limits',
+      'Priority support',
     ],
   },
   {
     name: 'Enterprise',
-    price: 'Custom',
-    period: '',
-    description: 'For agencies, chains, and multi-location enterprises.',
+    price: '₹8,333',
+    period: '/ month',
+    priceNote: '₹1,00,000 billed annually',
+    description: 'Full-feature tier with no restrictions.',
     cta: 'Talk to Sales',
     ctaHref: '/contact',
     ctaExternal: false,
     highlighted: false,
     features: [
-      'Unlimited locations',
-      'White-label platform',
-      'Custom domain',
-      'Dedicated account manager',
-      'SLA-backed uptime',
-      'SSO / SAML authentication',
-      'Custom integrations & CRM sync',
-      'Quarterly business reviews',
+      'Everything in Pro',
+      'Unlimited commerce options',
+      'Voice Call Agent (upcoming)',
+      'Industry templates',
+      'Dedicated support & onboarding',
     ],
   },
 ];
+
+function PlanCard({ plan }: { plan: Plan }) {
+  return (
+    <div
+      className={`relative rounded-2xl p-6 flex flex-col ${
+        plan.highlighted
+          ? 'bg-[#0A1628] border-2 border-[#1A52E0] shadow-[0_0_40px_rgba(26,82,224,0.25)]'
+          : 'bg-[#0A1628] border border-white/10'
+      }`}
+    >
+      {plan.badge && (
+        <div className="absolute -top-3 left-1/2 -translate-x-1/2">
+          <span className="chip-recommended text-xs">{plan.badge}</span>
+        </div>
+      )}
+
+      <div className="mb-6">
+        <p className="text-sm font-semibold text-slate-200 uppercase tracking-wider mb-1">{plan.name}</p>
+        <div className="flex items-end gap-1 mb-1">
+          <span className="text-4xl font-bold text-white">{plan.price}</span>
+          {plan.period && <span className="text-slate-300 mb-1">{plan.period}</span>}
+        </div>
+        {plan.priceNote && <p className="text-xs text-slate-400 mb-2">{plan.priceNote}</p>}
+        <p className="text-sm text-slate-200">{plan.description}</p>
+      </div>
+
+      <ul className="space-y-3 mb-8 flex-1">
+        {plan.features.map((feature) => (
+          <li key={feature} className="flex items-start gap-2.5 text-sm text-white/85">
+            <CheckCircle className="w-4 h-4 text-success-400 flex-shrink-0 mt-0.5" />
+            {feature}
+          </li>
+        ))}
+      </ul>
+
+      {plan.ctaExternal ? (
+        <a
+          href={plan.ctaHref}
+          target="_blank"
+          rel="noopener noreferrer"
+          className={`inline-flex items-center justify-center gap-2 px-6 py-3 rounded-lg font-semibold text-sm transition-all ${
+            plan.highlighted
+              ? 'bg-white text-[#050D1A] hover:shadow-[0_0_20px_rgba(6,206,255,0.3)] hover:scale-[1.02]'
+              : 'border border-white/20 text-white hover:bg-white/10'
+          }`}
+        >
+          {plan.cta} <ArrowRight className="w-4 h-4" />
+        </a>
+      ) : (
+        <Link
+          href={plan.ctaHref}
+          className="inline-flex items-center justify-center gap-2 px-6 py-3 rounded-lg font-semibold text-sm border border-white/20 text-white hover:bg-white/10 transition-all"
+        >
+          {plan.cta} <ArrowRight className="w-4 h-4" />
+        </Link>
+      )}
+    </div>
+  );
+}
 
 export function Pricing() {
   return (
@@ -86,7 +179,7 @@ export function Pricing() {
       <HeroSection
         badge={{ text: 'Transparent pricing, no surprises' }}
         title="Simple Pricing for Real Results"
-        description="Start free. Scale when you're ready. No long-term contracts, no hidden fees."
+        description="Transparent ₹ pricing with GST included. No long-term contracts, no hidden fees."
       />
 
       {/* AI Review Generator Pricing */}
@@ -99,68 +192,39 @@ export function Pricing() {
             </div>
             <h2 className="text-3xl md:text-4xl font-bold text-white mb-3">AI Review Generator</h2>
             <p className="text-slate-200 max-w-xl mx-auto">
-              Collect authentic Google reviews in under 20 seconds. Used by businesses across multiple industries.
+              Get more Google reviews on autopilot — and reply to them with AI. One simple plan, everything included.
+            </p>
+          </div>
+
+          <div className="max-w-md mx-auto">
+            <PlanCard plan={reviewPlan} />
+          </div>
+        </div>
+      </section>
+
+      {/* Setu Pricing */}
+      <section className="py-16 md:py-24 bg-[#0A1628]">
+        <div className="container-main">
+          <div className="text-center mb-12">
+            <div className="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-success-500/10 border border-success-500/20 text-success-400 text-sm font-medium mb-4">
+              <span className="w-2 h-2 rounded-full bg-success-400 animate-pulse" />
+              Live Platform
+            </div>
+            <h2 className="text-3xl md:text-4xl font-bold text-white mb-3">Setu — WhatsApp Growth Platform</h2>
+            <p className="text-slate-200 max-w-xl mx-auto">
+              Broadcast campaigns, AI chatbot, shared inbox, lead pipeline, and WhatsApp commerce. All prices include 18% GST — annual billing saves two months.
             </p>
           </div>
 
           <div className="grid md:grid-cols-3 gap-6 max-w-5xl mx-auto">
-            {reviewPlans.map((plan) => (
-              <div
-                key={plan.name}
-                className={`relative rounded-2xl p-6 flex flex-col ${
-                  plan.highlighted
-                    ? 'bg-[#0A1628] border-2 border-[#1A52E0] shadow-[0_0_40px_rgba(26,82,224,0.25)]'
-                    : 'bg-[#0A1628] border border-white/10'
-                }`}
-              >
-                {plan.badge && (
-                  <div className="absolute -top-3 left-1/2 -translate-x-1/2">
-                    <span className="chip-recommended text-xs">{plan.badge}</span>
-                  </div>
-                )}
-
-                <div className="mb-6">
-                  <p className="text-sm font-semibold text-slate-200 uppercase tracking-wider mb-1">{plan.name}</p>
-                  <div className="flex items-end gap-1 mb-2">
-                    <span className="text-4xl font-bold text-white">{plan.price}</span>
-                    {plan.period && <span className="text-slate-300 mb-1">{plan.period}</span>}
-                  </div>
-                  <p className="text-sm text-slate-200">{plan.description}</p>
-                </div>
-
-                <ul className="space-y-3 mb-8 flex-1">
-                  {plan.features.map((feature) => (
-                    <li key={feature} className="flex items-start gap-2.5 text-sm text-white/85">
-                      <CheckCircle className="w-4 h-4 text-success-400 flex-shrink-0 mt-0.5" />
-                      {feature}
-                    </li>
-                  ))}
-                </ul>
-
-                {plan.ctaExternal ? (
-                  <a
-                    href={plan.ctaHref}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className={`inline-flex items-center justify-center gap-2 px-6 py-3 rounded-lg font-semibold text-sm transition-all ${
-                      plan.highlighted
-                        ? 'bg-white text-[#050D1A] hover:shadow-[0_0_20px_rgba(6,206,255,0.3)] hover:scale-[1.02]'
-                        : 'border border-white/20 text-white hover:bg-white/10'
-                    }`}
-                  >
-                    {plan.cta} <ArrowRight className="w-4 h-4" />
-                  </a>
-                ) : (
-                  <Link
-                    href={plan.ctaHref}
-                    className="inline-flex items-center justify-center gap-2 px-6 py-3 rounded-lg font-semibold text-sm border border-white/20 text-white hover:bg-white/10 transition-all"
-                  >
-                    {plan.cta} <ArrowRight className="w-4 h-4" />
-                  </Link>
-                )}
-              </div>
+            {setuPlans.map((plan) => (
+              <PlanCard key={plan.name} plan={plan} />
             ))}
           </div>
+
+          <p className="text-center text-sm text-slate-400 mt-8 max-w-2xl mx-auto">
+            WhatsApp conversation charges (Meta fees) are billed separately at cost with 0% markup — marketing ₹0.88, utility/authentication ₹0.115 per conversation, and service replies free within the 24-hour window.
+          </p>
         </div>
       </section>
 
@@ -195,19 +259,23 @@ export function Pricing() {
               {[
                 {
                   q: 'Is there a free trial?',
-                  a: 'Yes — the AI Review Generator Starter plan is permanently free for one location with up to 30 review requests per month. No credit card required.',
+                  a: 'The AI Review Generator is self-serve — create your account at reviews.vyaptix.ai and cancel anytime. For Setu, book a product demo and get a 14-day read-only demo account before subscribing.',
                 },
                 {
                   q: 'Can I change plans later?',
-                  a: "Absolutely. You can upgrade or downgrade your AI Review Generator plan at any time. Changes take effect at the start of your next billing cycle.",
+                  a: 'Absolutely. You can upgrade or downgrade your Setu plan at any time. The AI Review Generator is one simple plan — cancel anytime, no lock-in.',
                 },
                 {
-                  q: 'Do you offer annual billing?',
-                  a: 'Yes — annual plans include a 20% discount. Contact us or ask during your demo to get an annual quote.',
+                  q: 'Are taxes included in the prices?',
+                  a: 'Yes — all listed prices include 18% GST. Setu annual billing saves two months versus paying monthly.',
+                },
+                {
+                  q: 'Are WhatsApp message charges included in Setu plans?',
+                  a: 'WhatsApp conversation charges set by Meta are billed separately at cost with 0% markup — marketing conversations at ₹0.88, utility and authentication at ₹0.115, and service replies free within the 24-hour customer window.',
                 },
                 {
                   q: 'What payment methods do you accept?',
-                  a: 'We accept all major credit cards, debit cards, and bank transfers for annual enterprise contracts.',
+                  a: 'We accept all major credit cards, debit cards, UPI, and bank transfers for annual contracts.',
                 },
               ].map(({ q, a }) => (
                 <div key={q} className="border-b border-white/10 pb-6">

--- a/src/views/Setu.tsx
+++ b/src/views/Setu.tsx
@@ -47,8 +47,8 @@ const features = [
   },
   {
     icon: <Bot className="w-6 h-6" />,
-    title: '24/7 AI Chatbot',
-    description: 'Deploy welcome flows, business-hours menus, keyword triggers, and service trees — no coding required. Your chatbot qualifies and captures leads while you sleep.',
+    title: '24/7 AI Chatbot & Flow Builder',
+    description: 'Deploy welcome flows, business-hours menus, and keyword triggers — no coding required. Design rich WhatsApp journeys visually with drag-and-drop nodes and ready-made templates.',
   },
   {
     icon: <Inbox className="w-6 h-6" />,
@@ -82,8 +82,8 @@ const features = [
   },
   {
     icon: <Zap className="w-6 h-6" />,
-    title: 'Consent-First Messaging',
-    description: 'Built-in STOP/opt-out handling, DPDP Act 2023 compliance, and Meta-approved flows — market confidently without regulatory risk.',
+    title: 'WhatsApp Commerce',
+    description: 'Publish a product catalogue, share products in a tap, and take orders right inside the chat your customers already use — turn conversations into sales.',
   },
 ];
 
@@ -117,7 +117,7 @@ const howItWorks = [
 
 const industries = [
   { icon: <ShoppingBag className="w-6 h-6" />, name: 'Retail & eCommerce', stat: '3× higher reply rate vs email' },
-  { icon: <Stethoscope className="w-6 h-6" />, name: 'Healthcare & Clinics', stat: 'Appointment reminders at 98% open rate' },
+  { icon: <Stethoscope className="w-6 h-6" />, name: 'Healthcare & Clinics', stat: 'Appointment reminders at 90%+ open rate' },
   { icon: <GraduationCap className="w-6 h-6" />, name: 'Education & EdTech', stat: 'Enrolment drip campaigns that convert' },
   { icon: <Home className="w-6 h-6" />, name: 'Real Estate', stat: 'Lead pipeline from inquiry to site visit' },
   { icon: <Building2 className="w-6 h-6" />, name: 'Finance & Insurance', stat: 'Policy renewal reminders that get read' },
@@ -125,7 +125,7 @@ const industries = [
 ];
 
 const stats = [
-  { value: 98, suffix: '%', label: 'WhatsApp message open rate' },
+  { value: 90, suffix: '%+', label: 'WhatsApp message open rate' },
   { value: 3, suffix: '×', label: 'Higher reply rate vs email' },
   { value: 2, suffix: ' min', label: 'To launch a campaign' },
   { value: 18, suffix: '+', label: 'Industries served' },
@@ -150,7 +150,11 @@ const faqs = [
   },
   {
     question: 'What is the pricing?',
-    answer: 'Setu starts at ₹999/month. The price includes your workspace, contacts, campaigns, AI chatbot, team inbox, and analytics. WhatsApp conversation charges (Meta fees) are billed separately based on usage. Contact us for custom pricing on high-volume plans.',
+    answer: 'Setu has three plans: Growth at ₹30,000/year (₹2,500/month), Pro at ₹50,000/year (₹4,167/month), and Enterprise at ₹1,00,000/year (₹8,333/month). All prices include 18% GST, and annual billing saves two months versus monthly. WhatsApp conversation charges (Meta fees) are billed separately at cost with 0% markup — marketing conversations at ₹0.88, utility/authentication at ₹0.115, and service replies free within the 24-hour window.',
+  },
+  {
+    question: 'Is there a free trial?',
+    answer: 'After a product demo, you get a 14-day read-only demo account to explore the platform with real data. Once the trial period ends, we send an invoice to begin your subscription. You can upgrade or downgrade your plan anytime.',
   },
   {
     question: 'Can I add multiple team members?',
@@ -165,10 +169,10 @@ const softwareJsonLd = {
   applicationCategory: 'BusinessApplication',
   operatingSystem: 'Web',
   url: 'https://setu.vyaptix.ai',
-  description: 'WhatsApp marketing platform for business teams — broadcast campaigns, AI chatbot, shared team inbox, lead pipeline, and analytics. 98% open rate. Live in 2 minutes.',
+  description: 'WhatsApp growth platform for business teams — broadcast campaigns, AI chatbot, visual flow builder, shared team inbox, lead pipeline, WhatsApp commerce, and analytics. 90%+ open rate. Live in 2 minutes.',
   offers: {
     '@type': 'Offer',
-    price: '999',
+    price: '2500',
     priceCurrency: 'INR',
     availability: 'https://schema.org/InStock',
   },
@@ -230,10 +234,10 @@ export function Setu() {
 
       <HeroSection
         badge={{ text: 'Live Platform', dot: 'green' }}
-        title="WhatsApp Marketing That Scales With Your Business"
-        description="Send campaigns to thousands, automate replies 24/7, manage your entire team inbox, and close more leads — all on WhatsApp. One platform. Every channel of your customer conversation."
+        title="Grow Your Business on WhatsApp"
+        description="One platform to broadcast campaigns, automate replies 24/7, run a shared team inbox, capture leads, and sell on WhatsApp — built for every business. VyaptIX is an official Meta Tech Provider."
         actions={[
-          { text: 'Start Free', href: 'https://setu.vyaptix.ai', variant: 'primary', external: true },
+          { text: 'Get Started', href: 'https://setu.vyaptix.ai', variant: 'primary', external: true },
           { text: 'Schedule Demo', href: '/demo', variant: 'secondary' },
         ]}
       />
@@ -544,7 +548,7 @@ export function Setu() {
               className="inline-flex items-center justify-center gap-2 px-8 py-4 font-semibold rounded-lg hover:scale-[1.03] transition-all"
               style={{ background: SETU_GREEN, color: '#050D1A' }}
             >
-              Get Started — ₹999/month <ExternalLink className="w-5 h-5" />
+              Get Started — from ₹2,500/month <ExternalLink className="w-5 h-5" />
             </a>
             <Link
               href="/demo"

--- a/src/views/Solutions.tsx
+++ b/src/views/Solutions.tsx
@@ -14,7 +14,7 @@ const PRODUCTS = [
   {
     id: 'ai-review',
     name: 'AI Review Generator',
-    tagline: 'Authentic Google reviews in under 20 seconds.',
+    tagline: 'More Google reviews — on autopilot, in about 20 seconds.',
     accentColor: '#06CEFF',
     Icon: Star,
     statusLabel: 'Live',
@@ -23,12 +23,12 @@ const PRODUCTS = [
     statusBorder: 'rgba(74,222,128,0.22)',
     href: '/solutions/ai-review-generation',
     externalHref: 'https://reviews.vyaptix.ai',
-    externalLabel: 'Try Free',
+    externalLabel: 'Get Started',
   },
   {
     id: 'setu',
     name: 'Setu',
-    tagline: 'WhatsApp marketing that scales with your business.',
+    tagline: 'WhatsApp growth platform — campaigns, chatbot, inbox & commerce.',
     accentColor: '#25D366',
     Icon: MessageCircle,
     statusLabel: 'Live',
@@ -37,7 +37,7 @@ const PRODUCTS = [
     statusBorder: 'rgba(74,222,128,0.22)',
     href: '/solutions/setu',
     externalHref: 'https://setu.vyaptix.ai',
-    externalLabel: 'Start Free',
+    externalLabel: 'Get Started',
   },
   {
     id: 'banklens',
@@ -306,7 +306,7 @@ export function Solutions() {
             <span style={{ color: '#06CEFF' }}>Scale with the right fit.</span>
           </h2>
           <p className="text-slate-400 mb-10 max-w-lg mx-auto text-sm leading-relaxed">
-            Every product is live and built for real business teams. Try one free, or book a call and we'll walk you through exactly what fits your workflow.
+            Every product is live and built for real business teams. Get started in minutes, or book a call and we'll walk you through exactly what fits your workflow.
           </p>
           <div className="flex flex-col sm:flex-row gap-4 justify-center">
             <a
@@ -315,7 +315,7 @@ export function Solutions() {
               rel="noopener noreferrer"
               className="inline-flex items-center justify-center gap-2 px-7 py-3.5 font-semibold text-[#050D1A] bg-white rounded-xl hover:shadow-[0_0_28px_rgba(6,206,255,0.3)] transition-all text-sm"
             >
-              Try AI Review Generator Free <ExternalLink className="w-4 h-4" />
+              Try AI Review Generator <ExternalLink className="w-4 h-4" />
             </a>
             <Link
               href="/contact"


### PR DESCRIPTION
Update marketing content across the site to match the latest product subwebsites (reviews.vyaptix.ai, setu.vyaptix.ai), and add Google branding to the AI Review Generator page.

AI Review Generator:
- New "Get more Google reviews on autopilot" positioning with the
  Collect / Reply / Grow story and the Google Review Inbox feature
- 4-step flow, real stats (84% completion, 50+ businesses, +38/mo)
- Launch pricing ₹1,299/mo incl. GST (removes old Free/$49 tiers)
- Google branding: multicolor "G" mark in hero badge, headline accent,
  trust row, features eyebrow, and a "Works with Google Business
  Profile" banner, plus the Google trademark disclaimer

Setu:
- Corrected open rate to 90%+ (was 98%) everywhere
- Added WhatsApp Commerce and visual flow builder capabilities
- New tiered pricing: Growth ₹2,500 / Pro ₹4,167 / Enterprise ₹8,333
  per month (incl. GST), with Meta pass-through fee note

Shared:
- New reusable Google SVG component
- hero-section badge now accepts an icon; title accepts rich content
- Updated Pricing view (adds Setu tiers), Home/Solutions cards,
  Header nav descriptions, route metadata, and llms.txt

